### PR TITLE
Preserve type

### DIFF
--- a/src/Rs/Json/Patch.php
+++ b/src/Rs/Json/Patch.php
@@ -17,15 +17,15 @@ class Patch
     private $targetDocument;
 
     /**
-     * @var Rs\Json\Patch\Document
+     * @var \Rs\Json\Patch\Document
      */
-    private $patchDocument;
+    private $jsonPatchDocument;
 
     /**
      * @param  string $targetDocument
      * @param  string $patchDocument
-     * @throws Rs\Json\Patch\InvalidTargetDocumentJsonException
-     * @throws Rs\Json\Patch\InvalidPatchDocumentJsonException
+     * @throws \Rs\Json\Patch\InvalidTargetDocumentJsonException
+     * @throws \Rs\Json\Patch\InvalidPatchDocumentJsonException
      */
     public function __construct($targetDocument, $patchDocument)
     {
@@ -44,7 +44,7 @@ class Patch
     }
 
     /**
-     * @throws Rs\Json\Patch\FailedTestException
+     * @throws \Rs\Json\Patch\FailedTestException
      *
      * @return string
      */

--- a/src/Rs/Json/Patch.php
+++ b/src/Rs/Json/Patch.php
@@ -52,6 +52,9 @@ class Patch
     {
         $patchOperations = $this->jsonPatchDocument->getPatchOperations();
         $patchedDocument = $this->targetDocument;
+
+        $wasObject = '{' === mb_substr(trim($patchedDocument), 0, 1);
+
         foreach ($patchOperations as $index => $patchOperation) {
             $targetDocument = $patchOperation->perform($patchedDocument);
             if ($patchOperation instanceof Test && $targetDocument === false) {
@@ -61,6 +64,15 @@ class Patch
                 $patchedDocument = $targetDocument;
             }
         }
+
+        $emtpyArray = '[]';
+        $emptyObject = '{}';
+        if ($patchedDocument === $emtpyArray && $wasObject) {
+            $patchedDocument = $emptyObject;
+        } elseif ($patchedDocument === $emptyObject && !$wasObject) {
+            $patchedDocument = $emtpyArray;
+        }
+
         return $patchedDocument;
     }
 }

--- a/src/Rs/Json/Patch/Document.php
+++ b/src/Rs/Json/Patch/Document.php
@@ -19,7 +19,7 @@ class Document
 
     /**
      * @param  string $patchDocument
-     * @throws Rs\Json\Patch\InvalidOperationException
+     * @throws \Rs\Json\Patch\InvalidOperationException
      */
     public function __construct($patchDocument)
     {
@@ -36,7 +36,7 @@ class Document
 
     /**
      * @param  string $patchDocument The patch document containing the patch operations.
-     * @throws Rs\Json\Patch\InvalidOperationException
+     * @throws \Rs\Json\Patch\InvalidOperationException
      *
      * @return array
      */
@@ -65,6 +65,8 @@ class Document
 
     /**
      * @param mixed $patchDocument
+     *
+     * @return bool
      */
     private function isEmptyPatchDocument($patchDocument)
     {
@@ -76,9 +78,9 @@ class Document
 
     /**
      * @param  \stdClass $possiblePatchOperation
-     * @throws Rs\Json\Patch\InvalidOperationException
+     * @throws \Rs\Json\Patch\InvalidOperationException
      *
-     * @return Rs\Json\Patch\Operation or null on unsupported patch operation
+     * @return \Rs\Json\Patch\Operation or null on unsupported patch operation
      */
     private function patchOperationFactory(\stdClass $possiblePatchOperation)
     {

--- a/src/Rs/Json/Patch/FailedTestException.php
+++ b/src/Rs/Json/Patch/FailedTestException.php
@@ -1,4 +1,8 @@
 <?php
 namespace Rs\Json\Patch;
 
-class FailedTestException extends \Exception {}
+use Exception;
+
+class FailedTestException extends Exception
+{
+}

--- a/src/Rs/Json/Patch/InvalidOperationException.php
+++ b/src/Rs/Json/Patch/InvalidOperationException.php
@@ -1,4 +1,8 @@
 <?php
 namespace Rs\Json\Patch;
 
-class InvalidOperationException extends \Exception {}
+use Exception;
+
+class InvalidOperationException extends Exception
+{
+}

--- a/src/Rs/Json/Patch/InvalidPatchDocumentJsonException.php
+++ b/src/Rs/Json/Patch/InvalidPatchDocumentJsonException.php
@@ -1,4 +1,8 @@
 <?php
 namespace Rs\Json\Patch;
 
-class InvalidPatchDocumentJsonException extends \Exception {}
+use Exception;
+
+class InvalidPatchDocumentJsonException extends Exception
+{
+}

--- a/src/Rs/Json/Patch/InvalidTargetDocumentJsonException.php
+++ b/src/Rs/Json/Patch/InvalidTargetDocumentJsonException.php
@@ -1,4 +1,8 @@
 <?php
 namespace Rs\Json\Patch;
 
-class InvalidTargetDocumentJsonException extends \Exception {}
+use Exception;
+
+class InvalidTargetDocumentJsonException extends Exception
+{
+}

--- a/src/Rs/Json/Patch/Operation.php
+++ b/src/Rs/Json/Patch/Operation.php
@@ -1,8 +1,6 @@
 <?php
 namespace Rs\Json\Patch;
 
-use Rs\Json\Patch\InvalidOperationException;
-
 abstract class Operation
 {
     /**
@@ -23,7 +21,7 @@ abstract class Operation
     /**
      * @param  string     $op
      * @param  \stdClass  $operation
-     * @throws Rs\Json\Patch\InvalidOperationException
+     * @throws \Rs\Json\Patch\InvalidOperationException
      */
     public function __construct($op, \stdClass $operation)
     {
@@ -91,7 +89,7 @@ abstract class Operation
      * Guard the mandatory operation properties
      *
      * @param  \stdClass $operation The operation structure.
-     * @throws Rs\Json\Patch\InvalidOperationException
+     * @throws \Rs\Json\Patch\InvalidOperationException
      */
     abstract protected function assertMandatories(\stdClass $operation);
 }

--- a/src/Rs/Json/Patch/Operations/Add.php
+++ b/src/Rs/Json/Patch/Operations/Add.php
@@ -21,7 +21,7 @@ class Add extends Operation
      * Guard the mandatory operation property
      *
      * @param  \stdClass $operation The operation structure.
-     * @throws Rs\Json\Patch\InvalidOperationException
+     * @throws \Rs\Json\Patch\InvalidOperationException
      */
     protected function assertMandatories(\stdClass $operation)
     {

--- a/src/Rs/Json/Patch/Operations/Copy.php
+++ b/src/Rs/Json/Patch/Operations/Copy.php
@@ -35,7 +35,7 @@ class Copy extends Operation
      * Guard the mandatory operation property
      *
      * @param  \stdClass $operation The operation structure.
-     * @throws Rs\Json\Patch\InvalidOperationException
+     * @throws \Rs\Json\Patch\InvalidOperationException
      */
     protected function assertMandatories(\stdClass $operation)
     {

--- a/src/Rs/Json/Patch/Operations/Move.php
+++ b/src/Rs/Json/Patch/Operations/Move.php
@@ -35,7 +35,7 @@ class Move extends Operation
      * Guard the mandatory operation property
      *
      * @param  \stdClass $operation The operation structure.
-     * @throws Rs\Json\Patch\InvalidOperationException
+     * @throws \Rs\Json\Patch\InvalidOperationException
      */
     protected function assertMandatories(\stdClass $operation)
     {

--- a/src/Rs/Json/Patch/Operations/Remove.php
+++ b/src/Rs/Json/Patch/Operations/Remove.php
@@ -32,7 +32,7 @@ class Remove extends Operation
     {
         $pointer = new Pointer($targetDocument);
         try {
-            $get = $pointer->get($this->getPath());
+            $pointer->get($this->getPath());
         } catch (NonexistentValueReferencedException $e) {
             return $targetDocument;
         }

--- a/src/Rs/Json/Patch/Operations/Replace.php
+++ b/src/Rs/Json/Patch/Operations/Replace.php
@@ -21,7 +21,7 @@ class Replace extends Operation
      * Guard the mandatory operation property
      *
      * @param  \stdClass $operation The operation structure.
-     * @throws Rs\Json\Patch\InvalidOperationException
+     * @throws \Rs\Json\Patch\InvalidOperationException
      */
     protected function assertMandatories(\stdClass $operation)
     {

--- a/src/Rs/Json/Patch/Operations/Test.php
+++ b/src/Rs/Json/Patch/Operations/Test.php
@@ -21,7 +21,7 @@ class Test extends Operation
      * Guard the mandatory operation property
      *
      * @param  \stdClass $operation $operation The operation structure.
-     * @throws Rs\Json\Patch\InvalidOperationException
+     * @throws \Rs\Json\Patch\InvalidOperationException
      */
     protected function assertMandatories(\stdClass $operation)
     {


### PR DESCRIPTION
Keep the type of the json the same before and after all patches:

- `{...}` will stay `{}` when end result is empty
- `[...]` will stay `[]` when end result is empty