### PR TITLE
Require mbstring polyfill.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     },
     "require": {
         "php": ">=5.3.0",
-        "php-jsonpointer/php-jsonpointer": "1.1.*"
+        "php-jsonpointer/php-jsonpointer": "1.1.*",
+        "symfony/polyfill-mbstring": "^1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "4.6.*"


### PR DESCRIPTION
To ensure library will work with or without the mbstring extension.

If you didn't want to bring in extra dependencies will alter the PR to simply add the following to the composer.json

`"ext-mbstring": "*"`

Required due to use of `mb_substr()` [here](https://github.com/raphaelstolt/php-jsonpatch/blob/master/src/Rs/Json/Patch.php#L56) btw