### PR TITLE
Fix operation Test with int as string

### DIFF
--- a/src/Rs/Json/Patch/Operations/Test.php
+++ b/src/Rs/Json/Patch/Operations/Test.php
@@ -72,8 +72,8 @@ class Test extends Operation
     {
         if (is_string($string) && strlen($string)) {
             // Decode and check last error
-            json_decode($string);
-            return json_last_error() === JSON_ERROR_NONE;
+            $result = json_decode($string);
+            return (json_last_error() === JSON_ERROR_NONE) && ($result != $string);
         }
 
         return false;

--- a/tests/unit/Rs/Json/Patch/Operations/TestTest.php
+++ b/tests/unit/Rs/Json/Patch/Operations/TestTest.php
@@ -310,6 +310,10 @@ class TestTest extends \PHPUnit_Framework_TestCase
             array(array(
                 'given-json' => '{"foo":{"coo":{"koo":"roo","moo":"zoo"}}}',
                 'test-operation' => (object) array('path' => '/foo/coo', 'value' => array("koo" => "roo", "moo" => "zoo")),
+            )),
+            array(array(
+                'given-json' => '{"foo":"123"}',
+                'test-operation' => (object) array('path' => '/foo', 'value' => "123"),
             ))
         );
     }


### PR DESCRIPTION
When pass string with only numbers like `"123"` method `perform` trying to decode it as json and result will be int `123`.
This PR fixes this behavior.