### PR TITLE
Changed $rootGet to respect deep JSON pointers

### DIFF
--- a/src/Rs/Json/Patch/Operations/Add.php
+++ b/src/Rs/Json/Patch/Operations/Add.php
@@ -62,7 +62,7 @@ class Add extends Operation
 
         if (count($pointerParts) >= 2) {
             try {
-               $rootGet = $pointer->get(Pointer::POINTER_CHAR . $rootPointer);
+               $rootGet = $pointer->get(Pointer::POINTER_CHAR . implode('/', array_slice($pointerParts, 0, -1)));
             } catch (NonexistentValueReferencedException $e) {
                return $targetDocument;
             }


### PR DESCRIPTION
The second $rootGet does not properly reference the root for pointers with
>2 parts.  It assumes that the 0th array position is the new root, when it
should be that the pointer just above the last reference.