### PR TITLE
Add ability to disable patch operations by bitmask

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ Patch operations are defined in JSON and bundled in an array. Available JSON Pat
 and `test`; if their mandatory properties are not set a `Rs\Json\Patch\InvalidOperationException` will be
 thrown.
 
+You can if necessary disable some operations by setting a whitelist bitmask in the constructor.
+For example: `$document = new Document($patchDocument, Add::APPLY | Copy::APPLY | Replace::APPLY | Remove::APPLY);`
+This will not allow to use move or test in the document. If used, these operations are just ignored.
+The default is to allow all operations.
+
 ``` php
 <?php require_once 'vendor/autoload.php';
 

--- a/src/Rs/Json/Patch.php
+++ b/src/Rs/Json/Patch.php
@@ -24,10 +24,11 @@ class Patch
     /**
      * @param  string $targetDocument
      * @param  string $patchDocument
+     * @param  int $allowedPatchOperations
      * @throws \Rs\Json\Patch\InvalidTargetDocumentJsonException
      * @throws \Rs\Json\Patch\InvalidPatchDocumentJsonException
      */
-    public function __construct($targetDocument, $patchDocument)
+    public function __construct($targetDocument, $patchDocument, $allowedPatchOperations = null)
     {
         json_decode($targetDocument, true);
         if (json_last_error() !== JSON_ERROR_NONE) {
@@ -40,7 +41,7 @@ class Patch
         }
 
         $this->targetDocument = $targetDocument;
-        $this->jsonPatchDocument = new Document($patchDocument);
+        $this->jsonPatchDocument = new Document($patchDocument, $allowedPatchOperations);
     }
 
     /**

--- a/src/Rs/Json/Patch/Document.php
+++ b/src/Rs/Json/Patch/Document.php
@@ -18,11 +18,20 @@ class Document
     private $patchOperations;
 
     /**
+     * @var int
+     */
+    private $allowedPatchOperations;
+
+    /**
      * @param  string $patchDocument
+     * @param  int $patchDocument
      * @throws \Rs\Json\Patch\InvalidOperationException
      */
-    public function __construct($patchDocument)
+    public function __construct($patchDocument, $allowedPatchOperations = null)
     {
+        $defaultPatchOperations = Add::APPLY | Copy::APPLY | Move::APPLY | Remove::APPLY | Replace::APPLY | Test::APPLY;
+        $this->allowedPatchOperations = null !== $allowedPatchOperations ? $allowedPatchOperations : $defaultPatchOperations;
+
         $this->patchOperations = $this->extractPatchOperations($patchDocument);
     }
 
@@ -91,21 +100,45 @@ class Document
 
         switch ($possiblePatchOperation->op) {
             case 'add':
+                if (!(($this->allowedPatchOperations & Add::APPLY) == Add::APPLY)) {
+                    return null;
+                }
+
                 return new Add($possiblePatchOperation);
                 break;
             case 'copy':
+                if (!(($this->allowedPatchOperations & Copy::APPLY) == Copy::APPLY)) {
+                    return null;
+                }
+
                 return new Copy($possiblePatchOperation);
                 break;
             case 'move':
+                if (!(($this->allowedPatchOperations & Move::APPLY) == Move::APPLY)) {
+                    return null;
+                }
+
                 return new Move($possiblePatchOperation);
                 break;
             case 'replace':
+                if (!(($this->allowedPatchOperations & Replace::APPLY) == Replace::APPLY)) {
+                    return null;
+                }
+
                 return new Replace($possiblePatchOperation);
                 break;
             case 'remove':
+                if (!(($this->allowedPatchOperations & Remove::APPLY) == Remove::APPLY)) {
+                    return null;
+                }
+
                 return new Remove($possiblePatchOperation);
                 break;
             case 'test':
+                if (!(($this->allowedPatchOperations & Test::APPLY) == Test::APPLY)) {
+                    return null;
+                }
+
                 return new Test($possiblePatchOperation);
                 break;
             default:

--- a/src/Rs/Json/Patch/Operations/Add.php
+++ b/src/Rs/Json/Patch/Operations/Add.php
@@ -9,6 +9,13 @@ use Rs\Json\Pointer\NonexistentValueReferencedException;
 class Add extends Operation
 {
     /**
+     * Used for bitmap operations to find out if allowed or not
+     * 
+     * @const int
+     */
+    const APPLY = 1;
+
+    /**
      * @param \stdClass $operation
      */
     public function __construct(\stdClass $operation)

--- a/src/Rs/Json/Patch/Operations/Copy.php
+++ b/src/Rs/Json/Patch/Operations/Copy.php
@@ -9,6 +9,13 @@ use Rs\Json\Pointer\NonexistentValueReferencedException;
 class Copy extends Operation
 {
     /**
+     * Used for bitmap operations to find out if allowed or not
+     *
+     * @const int
+     */
+    const APPLY = 2;
+
+    /**
      * @var string
      */
     protected $from;

--- a/src/Rs/Json/Patch/Operations/Move.php
+++ b/src/Rs/Json/Patch/Operations/Move.php
@@ -9,6 +9,13 @@ use Rs\Json\Pointer\NonexistentValueReferencedException;
 class Move extends Operation
 {
     /**
+     * Used for bitmap operations to find out if allowed or not
+     *
+     * @const int
+     */
+    const APPLY = 4;
+    
+    /**
      * @var string
      */
     protected $from;

--- a/src/Rs/Json/Patch/Operations/Remove.php
+++ b/src/Rs/Json/Patch/Operations/Remove.php
@@ -8,6 +8,13 @@ use Rs\Json\Pointer\NonexistentValueReferencedException;
 class Remove extends Operation
 {
     /**
+     * Used for bitmap operations to find out if allowed or not
+     *
+     * @const int
+     */
+    const APPLY = 8;
+
+    /**
      * @param \stdClass $operation
      */
     public function __construct(\stdClass $operation)

--- a/src/Rs/Json/Patch/Operations/Replace.php
+++ b/src/Rs/Json/Patch/Operations/Replace.php
@@ -9,6 +9,13 @@ use Rs\Json\Pointer\NonexistentValueReferencedException;
 class Replace extends Operation
 {
     /**
+     * Used for bitmap operations to find out if allowed or not
+     *
+     * @const int
+     */
+    const APPLY = 16;
+    
+    /**
      * @param \stdClass $operation
      */
     public function __construct(\stdClass $operation)

--- a/src/Rs/Json/Patch/Operations/Test.php
+++ b/src/Rs/Json/Patch/Operations/Test.php
@@ -9,6 +9,13 @@ use Rs\Json\Pointer\NonexistentValueReferencedException;
 class Test extends Operation
 {
     /**
+     * Used for bitmap operations to find out if allowed or not
+     *
+     * @const int
+     */
+    const APPLY = 32;
+
+    /**
      * @param \stdClass $operation
      */
     public function __construct(\stdClass $operation)


### PR DESCRIPTION
I could be useful to disallow some operations on a document (like remove). Therefore it is possible to set a value for each patch operation which should be allowed to use. Per default all are allowed.