### PR TITLE
fix issue with empty objects; added unit and integration tests

### DIFF
--- a/src/Rs/Json/Patch/Operations/Add.php
+++ b/src/Rs/Json/Patch/Operations/Add.php
@@ -10,7 +10,7 @@ class Add extends Operation
 {
     /**
      * Used for bitmap operations to find out if allowed or not
-     * 
+     *
      * @const int
      */
     const APPLY = 1;
@@ -78,7 +78,7 @@ class Add extends Operation
             }
         }
 
-        $targetDocument = json_decode($targetDocument, true);
+        $targetDocument = json_decode($targetDocument);
 
         $lastPointerPart = $pointerParts[count($pointerParts) - 1];
         $replacementValue = $this->getReplacementValue();
@@ -93,11 +93,19 @@ class Add extends Operation
                 return json_encode($targetDocument, JSON_UNESCAPED_UNICODE);
             }
             if (count($pointerParts) === 1) {
-                $targetDocument[$pointerParts[0]] = $value;
+                if (is_array($targetDocument)) {
+                    $targetDocument[$pointerParts[0]] = $value;
+                } else {
+                    $targetDocument->{$pointerParts[0]} = $value;
+                }
             } elseif (count($pointerParts) > 1) {
                 $augmentedDocument = &$targetDocument;
                 foreach ($pointerParts as $pointerPart) {
-                    $augmentedDocument = &$augmentedDocument[$pointerPart];
+                    if (is_array($augmentedDocument)) {
+                        $augmentedDocument = &$augmentedDocument[$pointerPart];
+                    } else {
+                        $augmentedDocument = &$augmentedDocument->{$pointerPart};
+                    }
                 }
                 $augmentedDocument = $value;
             }
@@ -123,7 +131,11 @@ class Add extends Operation
                 }
                 $augmentedDocument = &$targetDocument;
                 foreach ($pointerParts as $pointerPart) {
-                    $augmentedDocument = &$augmentedDocument[$pointerPart];
+                    if (is_array($augmentedDocument)) {
+                        $augmentedDocument = &$augmentedDocument[$pointerPart];
+                    } else {
+                        $augmentedDocument = &$augmentedDocument->{$pointerPart};
+                    }
                 }
                 $augmentedDocument = $targetArray;
             }
@@ -132,7 +144,7 @@ class Add extends Operation
                 if (count($targetDocument) > 0 && is_numeric($additionIndex)) {
                     array_splice($targetDocument, $additionIndex, 0, $replacementValue);
                 } else {
-                    $targetDocument[$additionIndex] = $value;
+                    $targetDocument->{$additionIndex} = $value;
                 }
             }
         }

--- a/tests/integration/Rs/Json/PatchAddTest.php
+++ b/tests/integration/Rs/Json/PatchAddTest.php
@@ -22,6 +22,24 @@ class PatchAddTest extends \PHPUnit_Framework_TestCase
             $patchedDocument
         );
     }
+
+    /**
+     * @test
+     */
+    public function shouldAddEmptyObject()
+    {
+        $targetDocument = '{"foo":{"obj": {"property": "value", "emptyObj": {}}}}';
+        $patchDocument = '[{"op":"add", "path":"/foo/obj/anotherProp", "value":"qux"}]';
+        $expectedDocument = '{"foo":{"obj": {"property": "value", "anotherProp": "qux", "emptyObj": {}}}}';
+
+        $patch = new Patch($targetDocument, $patchDocument);
+        $patchedDocument = $patch->apply();
+
+        $this->assertJsonStringEqualsJsonString(
+            $expectedDocument,
+            $patchedDocument
+        );
+    }
     /**
      * @test
      */

--- a/tests/unit/Rs/Json/Patch/Operations/AddTest.php
+++ b/tests/unit/Rs/Json/Patch/Operations/AddTest.php
@@ -51,7 +51,7 @@ class AddTest extends \PHPUnit_Framework_TestCase
         $operation->value = $value;
 
         $addOperation = new Add($operation);
-        
+
         $this->assertJsonStringEqualsJsonString(
             $expectedJson,
             $addOperation->perform($targetJson)
@@ -95,6 +95,27 @@ class AddTest extends \PHPUnit_Framework_TestCase
             $addOperation->perform($targetJson)
         );
     }
+
+    /**
+     * @test
+     */
+    public function shouldKeepObjectsAsObjects()
+    {
+        $targetJson = '{"foo": {"bar": "baz", "boo": {}}}';
+        $expectedJson = '{"foo": {"bar": "baz", "boo": {}, "baz": "qux"}}';
+
+        $operation = new \stdClass;
+        $operation->path = '/foo/baz';
+        $operation->value = 'qux';
+
+        $addOperation = new Add($operation);
+
+        $this->assertJsonStringEqualsJsonString(
+            $expectedJson,
+            $addOperation->perform($targetJson)
+        );
+    }
+
     /**
      * @test
      */


### PR DESCRIPTION
this should fix issue #28..

I added integration and unit test, this works fine now. IMHO only `add` operation is affected as the others have a different behavior that isn't affected.

The other 'empty lines' in the diff are just lines of spaces my IDE replaced with empty lines, I hope that doesn't disturb you ;-)