### PR TITLE
fix object handling in replace operation

### DIFF
--- a/tests/integration/Rs/Json/PatchReplaceTest.php
+++ b/tests/integration/Rs/Json/PatchReplaceTest.php
@@ -85,4 +85,23 @@ class PatchReplaceTest extends \PHPUnit_Framework_TestCase
             $patchedDocument
         );
     }
+
+    /**
+     * @test
+     * @ticket 30 (https://github.com/raphaelstolt/php-jsonpatch/issues/30)
+     */
+    public function shouldPreserveObjects()
+    {
+        $targetDocument = '{"foo":{"obj": {"property": "value", "emptyObj": {}}}}';
+        $patchDocument = '[{"op":"replace", "path":"/foo/obj/property", "value":"qux"}]';
+        $expectedDocument = '{"foo":{"obj": {"property": "qux", "emptyObj": {}}}}';
+
+        $patch = new Patch($targetDocument, $patchDocument);
+        $patchedDocument = $patch->apply();
+
+        $this->assertJsonStringEqualsJsonString(
+            $expectedDocument,
+            $patchedDocument
+        );
+    }
 }

--- a/tests/unit/Rs/Json/Patch/Operations/ReplaceTest.php
+++ b/tests/unit/Rs/Json/Patch/Operations/ReplaceTest.php
@@ -41,7 +41,7 @@ class ReplaceTest extends \PHPUnit_Framework_TestCase
     public function shouldNotReplaceOnNonexistentPath()
     {
         $targetJson = $expectedJson = '{"baz":"qux","foo":"bar"}';
-        
+
         $operation = new \stdClass;
         $operation->path = '/buz';
         $operation->value = 'boo';
@@ -51,6 +51,27 @@ class ReplaceTest extends \PHPUnit_Framework_TestCase
         $this->assertJsonStringEqualsJsonString(
             $expectedJson,
             $addOperation->perform($targetJson)
+        );
+    }
+
+    /**
+     * @test
+     * @ticket 30 (https://github.com/raphaelstolt/php-jsonpatch/issues/30)
+     */
+    public function shouldKeepObjectsAsObjects()
+    {
+        $targetJson = '{"foo": {"bar": "baz", "boo": {}}}';
+        $expectedJson = '{"foo": {"bar": "bing", "boo": {}}}';
+
+        $operation = new \stdClass;
+        $operation->path = '/foo/bar';
+        $operation->value = 'bing';
+
+        $replaceOperation = new Replace($operation);
+
+        $this->assertJsonStringEqualsJsonString(
+            $expectedJson,
+            $replaceOperation->perform($targetJson)
         );
     }
 


### PR DESCRIPTION
fixes #30 

same fix as in `AddOperation` but changed to the way `ReplaceOperation` works