### PR TITLE
adapt to php-pointer release that handles array/objects in a more concise way

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.4",
         "symfony/polyfill-mbstring": "^1.1",
-        "php-jsonpointer/php-jsonpointer": "^2.0"
+        "php-jsonpointer/php-jsonpointer": "^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "4.6.*",

--- a/src/Rs/Json/Patch/Operations/Add.php
+++ b/src/Rs/Json/Patch/Operations/Add.php
@@ -129,6 +129,13 @@ class Add extends Operation
                         $targetArray[$additionIndex] = $value;
                     }
                 }
+            }
+
+            if (is_object($targetArray)) {
+                $targetArray->{$additionIndex} = $value;
+            }
+
+            if (is_array($targetArray) || is_object($targetArray)) {
                 $augmentedDocument = &$targetDocument;
                 foreach ($pointerParts as $pointerPart) {
                     if (is_array($augmentedDocument)) {

--- a/tests/integration/Rs/Json/PatchAddTest.php
+++ b/tests/integration/Rs/Json/PatchAddTest.php
@@ -43,6 +43,24 @@ class PatchAddTest extends \PHPUnit_Framework_TestCase
     }
     /**
      * @test
+     * @ticket 33 (https://github.com/raphaelstolt/php-jsonpatch/issues/33)
+     */
+    public function shouldPreserveEmptyObjectSameLevel()
+    {
+        $targetDocument = '{"foo": {"bar": {"baz": {"boo": {}, "qux": "value"}}}}';
+        $patchDocument = '[{"op":"add", "path":"/foo/bar/baz/qux", "value":"otherValue"}]';
+        $expectedDocument = '{"foo": {"bar": {"baz": {"boo": {}, "qux": "otherValue"}}}}';
+
+        $patch = new Patch($targetDocument, $patchDocument);
+        $patchedDocument = $patch->apply();
+
+        $this->assertJsonStringEqualsJsonString(
+            $expectedDocument,
+            $patchedDocument
+        );
+    }
+    /**
+     * @test
      */
     public function shouldAddNestedObjectMemberAsExpected1()
     {

--- a/tests/integration/Rs/Json/PatchReplaceTest.php
+++ b/tests/integration/Rs/Json/PatchReplaceTest.php
@@ -104,4 +104,23 @@ class PatchReplaceTest extends \PHPUnit_Framework_TestCase
             $patchedDocument
         );
     }
+
+    /**
+     * @test
+     * @ticket 33 (https://github.com/raphaelstolt/php-jsonpatch/issues/33)
+     */
+    public function shouldPreserveObjectsSameLevel()
+    {
+        $targetDocument = '{"foo": {"bar": {"baz": {"boo": {}, "qux": "value"}}}}';
+        $patchDocument = '[{"op":"replace", "path":"/foo/bar/baz/qux", "value":"otherValue"}]';
+        $expectedDocument = '{"foo": {"bar": {"baz": {"boo": {}, "qux": "otherValue"}}}}';
+
+        $patch = new Patch($targetDocument, $patchDocument);
+        $patchedDocument = $patch->apply();
+
+        $this->assertJsonStringEqualsJsonString(
+            $expectedDocument,
+            $patchedDocument
+        );
+    }
 }

--- a/tests/unit/Rs/Json/Patch/Operations/AddTest.php
+++ b/tests/unit/Rs/Json/Patch/Operations/AddTest.php
@@ -119,6 +119,27 @@ class AddTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
+     * @ticket 33 (https://github.com/raphaelstolt/php-jsonpatch/issues/33)
+     */
+    public function shouldPreserveEmptyObjectSameLevel()
+    {
+        $targetJson = '{"foo": {"bar": {"baz": {"boo": {}, "qux": "value"}}}}';
+        $expectedJson = '{"foo": {"bar": {"baz": {"boo": {}, "qux": "otherValue"}}}}';
+
+        $operation = new \stdClass;
+        $operation->path = '/foo/bar/baz/qux';
+        $operation->value = 'otherValue';
+
+        $addOperation = new Add($operation);
+
+        $this->assertJsonStringEqualsJsonString(
+            $expectedJson,
+            $addOperation->perform($targetJson)
+        );
+    }
+
+    /**
+     * @test
      */
     public function shouldAddAnArrayValueAsExpected()
     {

--- a/tests/unit/Rs/Json/Patch/Operations/ReplaceTest.php
+++ b/tests/unit/Rs/Json/Patch/Operations/ReplaceTest.php
@@ -77,6 +77,27 @@ class ReplaceTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
+     * @ticket 33 (https://github.com/raphaelstolt/php-jsonpatch/issues/33)
+     */
+    public function shouldPreserveEmptyObjectSameLevel()
+    {
+        $targetJson = '{"foo": {"bar": {"baz": {"boo": {}, "qux": "value"}}}}';
+        $expectedJson = '{"foo": {"bar": {"baz": {"boo": {}, "qux": "otherValue"}}}}';
+
+        $operation = new \stdClass;
+        $operation->path = '/foo/bar/baz/qux';
+        $operation->value = 'otherValue';
+
+        $replaceOperation = new Replace($operation);
+
+        $this->assertJsonStringEqualsJsonString(
+            $expectedJson,
+            $replaceOperation->perform($targetJson)
+        );
+    }
+
+    /**
+     * @test
      * @ticket 5 (https://github.com/raphaelstolt/php-jsonpatch/issues/5)
      */
     public function shouldReplaceWhenPathValueIsNull()


### PR DESCRIPTION
this PR shows the adaption of PR raphaelstolt/php-jsonpointer#9, adds new tests for the new behavior and shows that all should be green.

The main problem in pointer is the following:

Given a JSON structure as this:
```json
{
  "bar": {},
  "baz": "qux"
}
```

if you `$pointer->get('')` and then patch you stuff, you will get:

```json
{
  "bar": [],
  "baz": "qux"
}
```

thus, `bar` type has changed..

~~@raphaelstolt as soon `raphaelstolt/php-jsonpointer` is tagged, I will remove my repository override, bump to new tag and squash this PR ;-) I just added that to let the tests run with my PR in it.~~ done