### PR TITLE
add tests for object properties after array path

### DIFF
--- a/tests/integration/Rs/Json/PatchAddTest.php
+++ b/tests/integration/Rs/Json/PatchAddTest.php
@@ -242,4 +242,42 @@ class PatchAddTest extends \PHPUnit_Framework_TestCase
             $patchedDocument
         );
     }
+
+    /**
+     * @test
+     * @ticket 37 (https://github.com/raphaelstolt/php-jsonpatch/issues/37)
+     */
+    public function shouldCorrectlyUseNumericIndexInObjectHandling()
+    {
+        $targetDocument = '{"foo": {"bar": {"baz": [ {"bar":"baz"}, {"bar":"qux"} ] }}}';
+        $patchDocument = '[{"op":"add", "path":"/foo/bar/baz/1", "value":{"bar":"otherValue"} }]';
+        $expectedDocument = '{"foo": {"bar": {"baz": [ {"bar":"baz"}, {"bar":"otherValue"}, {"bar":"qux"} ] }}}';
+
+        $patch = new Patch($targetDocument, $patchDocument);
+        $patchedDocument = $patch->apply();
+
+        $this->assertJsonStringEqualsJsonString(
+            $expectedDocument,
+            $patchedDocument
+        );
+    }
+
+    /**
+     * @test
+     * @ticket 37 (https://github.com/raphaelstolt/php-jsonpatch/issues/37)
+     */
+    public function shouldCorrectlyUseNumericIndexInObjectHandlingWithAddedSubProp()
+    {
+        $targetDocument = '{"foo": {"bar": {"baz": [ {"bar":"baz"}, {"bar":"qux"} ] }}}';
+        $patchDocument = '[{"op":"add", "path":"/foo/bar/baz/1/bar", "value":"otherValue"}]';
+        $expectedDocument = '{"foo": {"bar": {"baz": [ {"bar":"baz"}, {"bar":"otherValue"} ] }}}';
+
+        $patch = new Patch($targetDocument, $patchDocument);
+        $patchedDocument = $patch->apply();
+
+        $this->assertJsonStringEqualsJsonString(
+            $expectedDocument,
+            $patchedDocument
+        );
+    }
 }

--- a/tests/integration/Rs/Json/PatchReplaceTest.php
+++ b/tests/integration/Rs/Json/PatchReplaceTest.php
@@ -123,4 +123,42 @@ class PatchReplaceTest extends \PHPUnit_Framework_TestCase
             $patchedDocument
         );
     }
+
+    /**
+     * @test
+     * @ticket 37 (https://github.com/raphaelstolt/php-jsonpatch/issues/37)
+     */
+    public function shouldCorrectlyUseNumericIndexInObjectHandling()
+    {
+        $targetDocument = '{"foo": {"bar": {"baz": [ {"bar":"baz"}, {"bar":"qux"} ] }}}';
+        $patchDocument = '[{"op":"replace", "path":"/foo/bar/baz/1", "value":{"bar":"otherValue"} }]';
+        $expectedDocument = '{"foo": {"bar": {"baz": [ {"bar":"baz"}, {"bar":"otherValue"} ] }}}';
+
+        $patch = new Patch($targetDocument, $patchDocument);
+        $patchedDocument = $patch->apply();
+
+        $this->assertJsonStringEqualsJsonString(
+            $expectedDocument,
+            $patchedDocument
+        );
+    }
+
+    /**
+     * @test
+     * @ticket 37 (https://github.com/raphaelstolt/php-jsonpatch/issues/37)
+     */
+    public function shouldCorrectlyUseNumericIndexInObjectHandlingWithAddedSubProp()
+    {
+        $targetDocument = '{"foo": {"bar": {"baz": [ {"bar":"baz"}, {"bar":"qux"} ] }}}';
+        $patchDocument = '[{"op":"replace", "path":"/foo/bar/baz/1/bar", "value":"otherValue"}]';
+        $expectedDocument = '{"foo": {"bar": {"baz": [ {"bar":"baz"}, {"bar":"otherValue"} ] }}}';
+
+        $patch = new Patch($targetDocument, $patchDocument);
+        $patchedDocument = $patch->apply();
+
+        $this->assertJsonStringEqualsJsonString(
+            $expectedDocument,
+            $patchedDocument
+        );
+    }
 }

--- a/tests/unit/Rs/Json/Patch/Operations/AddTest.php
+++ b/tests/unit/Rs/Json/Patch/Operations/AddTest.php
@@ -140,6 +140,49 @@ class AddTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
+     * @ticket 37 (https://github.com/raphaelstolt/php-jsonpatch/issues/37)
+     */
+    public function shouldCorrectlyUseNumericIndexInObjectHandling()
+    {
+        $targetJson = '{"foo": {"bar": {"baz": [ {"bar":"baz"}, {"bar":"qux"} ] }}}';
+        $expectedJson = '{"foo": {"bar": {"baz": [ {"bar":"baz"}, {"bar":"otherValue"}, {"bar":"qux"} ] }}}';
+
+        $operation = new \stdClass;
+        $operation->path = '/foo/bar/baz/1';
+        $operation->value = new \stdClass();
+        $operation->value->bar = 'otherValue';
+
+        $addOperation = new Add($operation);
+
+        $this->assertJsonStringEqualsJsonString(
+            $expectedJson,
+            $addOperation->perform($targetJson)
+        );
+    }
+
+    /**
+     * @test
+     * @ticket 37 (https://github.com/raphaelstolt/php-jsonpatch/issues/37)
+     */
+    public function shouldCorrectlyUseNumericIndexInObjectHandlingWithAddedSubProp()
+    {
+        $targetJson = '{"foo": {"bar": {"baz": [ {"bar":"baz"}, {"bar":"qux"} ] }}}';
+        $expectedJson = '{"foo": {"bar": {"baz": [ {"bar":"baz"}, {"bar":"otherValue"} ] }}}';
+
+        $operation = new \stdClass;
+        $operation->path = '/foo/bar/baz/1/bar';
+        $operation->value = 'otherValue';
+
+        $addOperation = new Add($operation);
+
+        $this->assertJsonStringEqualsJsonString(
+            $expectedJson,
+            $addOperation->perform($targetJson)
+        );
+    }
+
+    /**
+     * @test
      */
     public function shouldAddAnArrayValueAsExpected()
     {

--- a/tests/unit/Rs/Json/Patch/Operations/ReplaceTest.php
+++ b/tests/unit/Rs/Json/Patch/Operations/ReplaceTest.php
@@ -98,6 +98,48 @@ class ReplaceTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
+     * @ticket 37 (https://github.com/raphaelstolt/php-jsonpatch/issues/37)
+     */
+    public function shouldCorrectlyUseNumericIndexInObjectHandling()
+    {
+        $targetJson = '{"foo": {"bar": {"baz": [ {"bar":"baz"}, {"bar":"qux"} ] }}}';
+        $expectedJson = '{"foo": {"bar": {"baz": [ {"bar":"baz"}, {"bar":"otherValue"} ] }}}';
+
+        $operation = new \stdClass;
+        $operation->path = '/foo/bar/baz/1';
+        $operation->value = '{"bar":"otherValue"}';
+
+        $replaceOperation = new Replace($operation);
+
+        $this->assertJsonStringEqualsJsonString(
+            $expectedJson,
+            $replaceOperation->perform($targetJson)
+        );
+    }
+
+    /**
+     * @test
+     * @ticket 37 (https://github.com/raphaelstolt/php-jsonpatch/issues/37)
+     */
+    public function shouldCorrectlyUseNumericIndexInObjectHandlingWithAddedSubProp()
+    {
+        $targetJson = '{"foo": {"bar": {"baz": [ {"bar":"baz"}, {"bar":"qux"} ] }}}';
+        $expectedJson = '{"foo": {"bar": {"baz": [ {"bar":"baz"}, {"bar":"otherValue"} ] }}}';
+
+        $operation = new \stdClass;
+        $operation->path = '/foo/bar/baz/1/bar';
+        $operation->value = 'otherValue';
+
+        $replaceOperation = new Replace($operation);
+
+        $this->assertJsonStringEqualsJsonString(
+            $expectedJson,
+            $replaceOperation->perform($targetJson)
+        );
+    }
+
+    /**
+     * @test
      * @ticket 5 (https://github.com/raphaelstolt/php-jsonpatch/issues/5)
      */
     public function shouldReplaceWhenPathValueIsNull()


### PR DESCRIPTION
so this should fail now, but be green after raphaelstolt/php-jsonpointer#11 has been merged and a new tag exists..

@raphaelstolt please re-run travis after the tag in `raphaelstolt/php-jsonpointer`..

thanks!