### PR TITLE
Replace now behaves like specified

### DIFF
--- a/src/Rs/Json/Patch/Operations/Replace.php
+++ b/src/Rs/Json/Patch/Operations/Replace.php
@@ -79,7 +79,7 @@ class Replace extends Operation
             $value = $this->getValue();
         }
 
-        if (is_object($json) && array_key_exists($pointerPart, get_object_vars($json))) {
+        if (is_object($json)) {
             if (count($pointerParts) === 0) {
                 $json->{$pointerPart} = $value;
             } else {
@@ -91,7 +91,7 @@ class Replace extends Operation
             }
         } elseif ($pointerPart === Pointer::LAST_ARRAY_ELEMENT_CHAR && is_array($json)) {
             $json[count($json) - 1] = $value;
-        } elseif (is_array($json) && isset($json[$pointerPart])) {
+        } elseif (is_array($json)) {
             if (count($pointerParts) === 0) {
                 $json[$pointerPart] = $value;
             } else {


### PR DESCRIPTION
http://jsonpatch.com/ specifies that "replace" should behave like "remove" followed by "add". If you currently have a document like this:

```
{
  "test": "abc"
}
```

and apply the following patch:

```
[
  {"op":"replace","path":"/foo","value":"123"}
]
```

the result looks like this:

```
{
  "test": "abc"
}
```

If you instead apply this patch:

```
[
  {"op":"remove","path":"/foo"},
  {"op":"add","path":"/foo","value":"123"}
]
```

the result looks like this:

```
{
  "test": "abc",
  "foo": "123"
}
```

