### PR TITLE
Fix typo & update missing PHPdocs

### DIFF
--- a/src/Rs/Json/Patch.php
+++ b/src/Rs/Json/Patch.php
@@ -9,7 +9,7 @@ use Rs\Json\Patch\FailedTestException;
 
 class Patch
 {
-    const MEDIA_TYPE = "application/json-patch+json";
+    const MEDIA_TYPE = 'application/json-patch+json';
 
     /**
      * @var string
@@ -27,6 +27,7 @@ class Patch
      * @param  int $allowedPatchOperations
      * @throws \Rs\Json\Patch\InvalidTargetDocumentJsonException
      * @throws \Rs\Json\Patch\InvalidPatchDocumentJsonException
+     * @throws \Rs\Json\Patch\InvalidOperationException
      */
     public function __construct($targetDocument, $patchDocument, $allowedPatchOperations = null)
     {
@@ -68,14 +69,14 @@ class Patch
             }
         }
 
-        $emtpyArray = '[]';
+        $emptyArray = '[]';
         $emptyObject = '{}';
-        if ($patchedDocument === $emtpyArray && $wasObject) {
+        if ($patchedDocument === $emptyArray && $wasObject) {
             $patchedDocument = $emptyObject;
         }
 
         if ($patchedDocument === $emptyObject && !$wasObject) {
-            $patchedDocument = $emtpyArray;
+            $patchedDocument = $emptyArray;
         }
 
         return $patchedDocument;

--- a/src/Rs/Json/Patch.php
+++ b/src/Rs/Json/Patch.php
@@ -25,6 +25,7 @@ class Patch
      * @param  string $targetDocument
      * @param  string $patchDocument
      * @param  int $allowedPatchOperations
+     *
      * @throws \Rs\Json\Patch\InvalidTargetDocumentJsonException
      * @throws \Rs\Json\Patch\InvalidPatchDocumentJsonException
      * @throws \Rs\Json\Patch\InvalidOperationException
@@ -46,9 +47,8 @@ class Patch
     }
 
     /**
-     * @throws \Rs\Json\Patch\FailedTestException
-     *
      * @return string
+     * @throws \Rs\Json\Patch\FailedTestException
      */
     public function apply()
     {

--- a/src/Rs/Json/Patch/Document.php
+++ b/src/Rs/Json/Patch/Document.php
@@ -23,6 +23,7 @@ class Document
     /**
      * @param  string $patchDocument
      * @param  int $allowedPatchOperations
+     *
      * @throws \Rs\Json\Patch\InvalidOperationException
      */
     public function __construct($patchDocument, $allowedPatchOperations = null)
@@ -43,9 +44,9 @@ class Document
 
     /**
      * @param  string $patchDocument The patch document containing the patch operations.
-     * @throws \Rs\Json\Patch\InvalidOperationException
      *
      * @return Operation[]
+     * @throws \Rs\Json\Patch\InvalidOperationException
      */
     private function extractPatchOperations($patchDocument)
     {
@@ -82,9 +83,9 @@ class Document
 
     /**
      * @param  \stdClass $possiblePatchOperation
-     * @throws \Rs\Json\Patch\InvalidOperationException
      *
      * @return \Rs\Json\Patch\Operation or null on unsupported patch operation
+     * @throws \Rs\Json\Patch\InvalidOperationException
      */
     private function patchOperationFactory(\stdClass $possiblePatchOperation)
     {

--- a/src/Rs/Json/Patch/Document.php
+++ b/src/Rs/Json/Patch/Document.php
@@ -1,8 +1,6 @@
 <?php
 namespace Rs\Json\Patch;
 
-use Rs\Json\Patch\InvalidOperationException;
-use Rs\Json\Patch\Operation;
 use Rs\Json\Patch\Operations\Add;
 use Rs\Json\Patch\Operations\Copy;
 use Rs\Json\Patch\Operations\Move;

--- a/src/Rs/Json/Patch/Operation.php
+++ b/src/Rs/Json/Patch/Operation.php
@@ -21,6 +21,7 @@ abstract class Operation
     /**
      * @param  string     $op
      * @param  \stdClass  $operation
+     *
      * @throws \Rs\Json\Patch\InvalidOperationException
      * @throws \RuntimeException
      */
@@ -90,6 +91,7 @@ abstract class Operation
      * Guard the mandatory operation properties
      *
      * @param  \stdClass $operation The operation structure.
+     *
      * @throws \Rs\Json\Patch\InvalidOperationException
      */
     abstract protected function assertMandatories(\stdClass $operation);

--- a/src/Rs/Json/Patch/Operation.php
+++ b/src/Rs/Json/Patch/Operation.php
@@ -22,6 +22,7 @@ abstract class Operation
      * @param  string     $op
      * @param  \stdClass  $operation
      * @throws \Rs\Json\Patch\InvalidOperationException
+     * @throws \RuntimeException
      */
     public function __construct($op, \stdClass $operation)
     {

--- a/src/Rs/Json/Patch/Operations/Add.php
+++ b/src/Rs/Json/Patch/Operations/Add.php
@@ -57,7 +57,6 @@ class Add extends Operation
      * @param  string $targetDocument
      *
      * @return string
-     *
      * @throws \Rs\Json\Pointer\InvalidJsonException
      * @throws \Rs\Json\Pointer\InvalidPointerException
      * @throws \Rs\Json\Pointer\NonWalkableJsonException

--- a/src/Rs/Json/Patch/Operations/Add.php
+++ b/src/Rs/Json/Patch/Operations/Add.php
@@ -17,6 +17,9 @@ class Add extends Operation
 
     /**
      * @param \stdClass $operation
+     *
+     * @throws \Rs\Json\Patch\InvalidOperationException
+     * @throws \RuntimeException
      */
     public function __construct(\stdClass $operation)
     {
@@ -28,6 +31,7 @@ class Add extends Operation
      * Guard the mandatory operation property
      *
      * @param  \stdClass $operation The operation structure.
+     *
      * @throws \Rs\Json\Patch\InvalidOperationException
      */
     protected function assertMandatories(\stdClass $operation)
@@ -53,6 +57,10 @@ class Add extends Operation
      * @param  string $targetDocument
      *
      * @return string
+     *
+     * @throws \Rs\Json\Pointer\InvalidJsonException
+     * @throws \Rs\Json\Pointer\InvalidPointerException
+     * @throws \Rs\Json\Pointer\NonWalkableJsonException
      */
     public function perform($targetDocument)
     {
@@ -86,7 +94,7 @@ class Add extends Operation
         if ($get === null && $lastPointerPart !== Pointer::LAST_ARRAY_ELEMENT_CHAR) {
             if (ctype_digit($lastPointerPart) && $lastPointerPart > count($rootGet)) {
                 if ($rootPointer == $lastPointerPart && is_array($targetDocument)) {
-                    if (intval($lastPointerPart) <= count($targetDocument) + 1) {
+                    if ((int) $lastPointerPart <= count($targetDocument) + 1) {
                         array_splice($targetDocument, $lastPointerPart, 0, $replacementValue);
                     }
                 }
@@ -148,7 +156,7 @@ class Add extends Operation
             }
 
             if ($targetArray === null) {
-                if (count($targetDocument) > 0 && is_numeric($additionIndex)) {
+                if (is_numeric($additionIndex) && count($targetDocument) > 0) {
                     array_splice($targetDocument, $additionIndex, 0, $replacementValue);
                 } else {
                     $targetDocument->{$additionIndex} = $value;

--- a/src/Rs/Json/Patch/Operations/Copy.php
+++ b/src/Rs/Json/Patch/Operations/Copy.php
@@ -59,7 +59,6 @@ class Copy extends Operation
      * @param  string $targetDocument
      *
      * @return string
-     *
      * @throws \Rs\Json\Patch\InvalidOperationException
      * @throws \Rs\Json\Pointer\InvalidJsonException
      * @throws \Rs\Json\Pointer\InvalidPointerException

--- a/src/Rs/Json/Patch/Operations/Copy.php
+++ b/src/Rs/Json/Patch/Operations/Copy.php
@@ -22,6 +22,9 @@ class Copy extends Operation
 
     /**
      * @param \stdClass $operation
+     *
+     * @throws \Rs\Json\Patch\InvalidOperationException
+     * @throws \RuntimeException
      */
     public function __construct(\stdClass $operation)
     {
@@ -42,6 +45,7 @@ class Copy extends Operation
      * Guard the mandatory operation property
      *
      * @param  \stdClass $operation The operation structure.
+     *
      * @throws \Rs\Json\Patch\InvalidOperationException
      */
     protected function assertMandatories(\stdClass $operation)
@@ -55,6 +59,12 @@ class Copy extends Operation
      * @param  string $targetDocument
      *
      * @return string
+     *
+     * @throws \Rs\Json\Patch\InvalidOperationException
+     * @throws \Rs\Json\Pointer\InvalidJsonException
+     * @throws \Rs\Json\Pointer\InvalidPointerException
+     * @throws \Rs\Json\Pointer\NonWalkableJsonException
+     * @throws \RuntimeException
      */
     public function perform($targetDocument)
     {

--- a/src/Rs/Json/Patch/Operations/Move.php
+++ b/src/Rs/Json/Patch/Operations/Move.php
@@ -14,7 +14,7 @@ class Move extends Operation
      * @const int
      */
     const APPLY = 4;
-    
+
     /**
      * @var string
      */
@@ -22,6 +22,9 @@ class Move extends Operation
 
     /**
      * @param \stdClass $operation
+     *
+     * @throws \Rs\Json\Patch\InvalidOperationException
+     * @throws \RuntimeException
      */
     public function __construct(\stdClass $operation)
     {
@@ -42,6 +45,7 @@ class Move extends Operation
      * Guard the mandatory operation property
      *
      * @param  \stdClass $operation The operation structure.
+     *
      * @throws \Rs\Json\Patch\InvalidOperationException
      */
     protected function assertMandatories(\stdClass $operation)
@@ -55,6 +59,12 @@ class Move extends Operation
      * @param  string $targetDocument
      *
      * @return string
+     *
+     * @throws \Rs\Json\Patch\InvalidOperationException
+     * @throws \Rs\Json\Pointer\InvalidJsonException
+     * @throws \Rs\Json\Pointer\InvalidPointerException
+     * @throws \Rs\Json\Pointer\NonWalkableJsonException
+     * @throws \RuntimeException
      */
     public function perform($targetDocument)
     {

--- a/src/Rs/Json/Patch/Operations/Move.php
+++ b/src/Rs/Json/Patch/Operations/Move.php
@@ -59,7 +59,6 @@ class Move extends Operation
      * @param  string $targetDocument
      *
      * @return string
-     *
      * @throws \Rs\Json\Patch\InvalidOperationException
      * @throws \Rs\Json\Pointer\InvalidJsonException
      * @throws \Rs\Json\Pointer\InvalidPointerException

--- a/src/Rs/Json/Patch/Operations/Remove.php
+++ b/src/Rs/Json/Patch/Operations/Remove.php
@@ -16,6 +16,9 @@ class Remove extends Operation
 
     /**
      * @param \stdClass $operation
+     *
+     * @throws \Rs\Json\Patch\InvalidOperationException
+     * @throws \RuntimeException
      */
     public function __construct(\stdClass $operation)
     {
@@ -36,6 +39,12 @@ class Remove extends Operation
      * @param  string $targetDocument
      *
      * @return string
+     *
+     * @throws \Rs\Json\Patch\InvalidOperationException
+     * @throws \Rs\Json\Pointer\InvalidJsonException
+     * @throws \Rs\Json\Pointer\InvalidPointerException
+     * @throws \Rs\Json\Pointer\NonWalkableJsonException
+     * @throws \RuntimeException
      */
     public function perform($targetDocument)
     {
@@ -53,8 +62,8 @@ class Remove extends Operation
     }
 
     /**
-     * @param array|object $json         The json_decode'd Json structure.
-     * @param array        $pointerParts The parts of the fed pointer.
+     * @param array|\stdClass $json         The json_decode'd Json structure.
+     * @param array           $pointerParts The parts of the fed pointer.
      */
     private function remove(&$json, array $pointerParts)
     {

--- a/src/Rs/Json/Patch/Operations/Remove.php
+++ b/src/Rs/Json/Patch/Operations/Remove.php
@@ -39,7 +39,6 @@ class Remove extends Operation
      * @param  string $targetDocument
      *
      * @return string
-     *
      * @throws \Rs\Json\Patch\InvalidOperationException
      * @throws \Rs\Json\Pointer\InvalidJsonException
      * @throws \Rs\Json\Pointer\InvalidPointerException

--- a/src/Rs/Json/Patch/Operations/Replace.php
+++ b/src/Rs/Json/Patch/Operations/Replace.php
@@ -17,6 +17,9 @@ class Replace extends Operation
 
     /**
      * @param \stdClass $operation
+     *
+     * @throws \Rs\Json\Patch\InvalidOperationException
+     * @throws \RuntimeException
      */
     public function __construct(\stdClass $operation)
     {
@@ -41,6 +44,12 @@ class Replace extends Operation
      * @param  string $targetDocument
      *
      * @return string
+     *
+     * @throws \Rs\Json\Patch\InvalidOperationException
+     * @throws \Rs\Json\Pointer\InvalidJsonException
+     * @throws \Rs\Json\Pointer\InvalidPointerException
+     * @throws \Rs\Json\Pointer\NonWalkableJsonException
+     * @throws \RuntimeException
      */
     public function perform($targetDocument)
     {

--- a/src/Rs/Json/Patch/Operations/Replace.php
+++ b/src/Rs/Json/Patch/Operations/Replace.php
@@ -31,6 +31,7 @@ class Replace extends Operation
      * Guard the mandatory operation property
      *
      * @param  \stdClass $operation The operation structure.
+     *
      * @throws \Rs\Json\Patch\InvalidOperationException
      */
     protected function assertMandatories(\stdClass $operation)
@@ -44,7 +45,6 @@ class Replace extends Operation
      * @param  string $targetDocument
      *
      * @return string
-     *
      * @throws \Rs\Json\Patch\InvalidOperationException
      * @throws \Rs\Json\Pointer\InvalidJsonException
      * @throws \Rs\Json\Pointer\InvalidPointerException

--- a/src/Rs/Json/Patch/Operations/Test.php
+++ b/src/Rs/Json/Patch/Operations/Test.php
@@ -31,7 +31,6 @@ class Test extends Operation
      * @param  string $targetDocument
      *
      * @return boolean
-     *
      * @throws \Rs\Json\Patch\InvalidOperationException
      * @throws \Rs\Json\Pointer\InvalidJsonException
      * @throws \Rs\Json\Pointer\InvalidPointerException

--- a/src/Rs/Json/Patch/Operations/Test.php
+++ b/src/Rs/Json/Patch/Operations/Test.php
@@ -17,6 +17,9 @@ class Test extends Operation
 
     /**
      * @param \stdClass $operation
+     *
+     * @throws \Rs\Json\Patch\InvalidOperationException
+     * @throws \RuntimeException
      */
     public function __construct(\stdClass $operation)
     {
@@ -25,22 +28,15 @@ class Test extends Operation
     }
 
     /**
-     * Guard the mandatory operation property
-     *
-     * @param  \stdClass $operation $operation The operation structure.
-     * @throws \Rs\Json\Patch\InvalidOperationException
-     */
-    protected function assertMandatories(\stdClass $operation)
-    {
-        if (!property_exists($operation, 'value')) {
-            throw new InvalidOperationException('Mandatory value property not set');
-        }
-    }
-
-    /**
      * @param  string $targetDocument
      *
      * @return boolean
+     *
+     * @throws \Rs\Json\Patch\InvalidOperationException
+     * @throws \Rs\Json\Pointer\InvalidJsonException
+     * @throws \Rs\Json\Pointer\InvalidPointerException
+     * @throws \Rs\Json\Pointer\NonWalkableJsonException
+     * @throws \RuntimeException
      */
     public function perform($targetDocument)
     {
@@ -79,6 +75,20 @@ class Test extends Operation
         }
 
         return ($get === $value);
+    }
+
+    /**
+     * Guard the mandatory operation property
+     *
+     * @param  \stdClass $operation $operation The operation structure.
+     *
+     * @throws \Rs\Json\Patch\InvalidOperationException
+     */
+    protected function assertMandatories(\stdClass $operation)
+    {
+        if (!property_exists($operation, 'value')) {
+            throw new InvalidOperationException('Mandatory value property not set');
+        }
     }
 
     /**


### PR DESCRIPTION
* Fixes a typo
* Adds missing @throws statements
* Normalizes the styling of the PHPdocs (@param first, then newline, then @return then @throws etc.)