### PR TITLE
allow toplevel remove

### DIFF
--- a/src/Rs/Json/Patch/Operations/Remove.php
+++ b/src/Rs/Json/Patch/Operations/Remove.php
@@ -92,7 +92,9 @@ class Remove extends Operation
         } elseif ($pointerPart === Pointer::LAST_ARRAY_ELEMENT_CHAR && is_array($json)) {
             unset($json[count($json) - 1]);
         } else {
-            if (is_object($json)) {
+            if (null === $pointerPart) {
+                $json = new \stdClass();
+            } elseif (is_object($json)) {
                 unset($json->{$pointerPart});
             } else {
                 unset($json[$pointerPart]);

--- a/tests/unit/Rs/Json/Patch/Operations/RemoveTest.php
+++ b/tests/unit/Rs/Json/Patch/Operations/RemoveTest.php
@@ -121,6 +121,11 @@ class RemoveTest extends \PHPUnit_Framework_TestCase
                 'expected-json' => '["done", "started", "pending", "archived"]',
                 'remove-operation' => (object) array('path' => '/2'),
             )),
+            array(array(
+                'given-json' => '{"baz":"qux"}',
+                'expected-json' => '{}',
+                'remove-operation' => (object) array('path' => ''),
+            )),
         );
     }
 }


### PR DESCRIPTION
as stated here "To point to the root of the document use an empty string for the pointer. The pointer / doesn’t point to the root, it points to a key of "" on the root (which is totally valid in JSON)." http://jsonpatch.com/ - JsonPointer