### PR TITLE
Suggest ext-mbstring or the Symfony polyfill

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,9 @@
         "symfony/polyfill-mbstring": "^1.1",
         "php-jsonpointer/php-jsonpointer": "^3.0"
     },
+    "suggest": {
+        "ext-mbstring": "If ext-mbstring is not available you MUST install symfony/polyfill-mbstring"
+    },
     "require-dev": {
         "phpunit/phpunit": "4.6.*",
         "friendsofphp/php-cs-fixer": "^2.0"


### PR DESCRIPTION
Patch::apply() relies on `mb_substr()` being available, which is only the case when either the Symfony polyfill or `ext-mbstring` are installed.

I've used https://github.com/thephpleague/climate/issues/109 as an example that fixes the same problem